### PR TITLE
fix bug parsing config files without a trailing newline

### DIFF
--- a/configfile.go
+++ b/configfile.go
@@ -211,7 +211,9 @@ func (c *ConfigFile) read(buf *bufio.Reader) error {
 	for {
 		l, err := buf.ReadString('\n') // parse line-by-line
 		if err == io.EOF {
-			break
+			if len(l) == 0 {
+				break
+			}
 		} else if err != nil {
 			return err
 		}

--- a/configfile_test.go
+++ b/configfile_test.go
@@ -178,7 +178,7 @@ func TestReadFile(t *testing.T) {
 	buf.WriteString("[secTION-2]\n")
 	buf.WriteString("IS-flag-TRUE=Yes\n")
 	buf.WriteString("[section-1]\n") // continue again [section-1]
-	buf.WriteString("option4=this_is_%(variable2)s.\n")
+	buf.WriteString("option4=this_is_%(variable2)s.")
 	buf.Flush()
 	file.Close()
 


### PR DESCRIPTION
Goconfig has a bug where the last line of the file does not get parsed if it does not contain a trailing newline.

Reading the last line without a trailing newline causes `ConfigFile.read` to return early because an EOF is signaled by `bufio.ReadString('\n')` even though bytes have been read. Fixed by waiting until `bufio.ReadString('\n')` returns both EOF and 0 bytes are read.
