### PR TITLE
Update unit tests to work on Windows

### DIFF
--- a/configfile_test.go
+++ b/configfile_test.go
@@ -157,7 +157,8 @@ func TestInMemory(t *testing.T) {
 
 // Create a 'tough' configuration file and test (read) parsing.
 func TestReadFile(t *testing.T) {
-	const tmp = "/tmp/__config_test.go__garbage"
+
+	tmp := os.TempDir() + "/__config_test.go__garbage"
 	defer os.Remove(tmp)
 
 	file, err := os.Create(tmp)
@@ -205,7 +206,7 @@ func TestReadFile(t *testing.T) {
 
 // Test writing and reading back a configuration file.
 func TestWriteReadFile(t *testing.T) {
-	const tmp = "/tmp/__config_test.go__garbage"
+	tmp := os.TempDir() + "/__config_test.go__garbage"
 	defer os.Remove(tmp)
 
 	cw := NewConfigFile()


### PR DESCRIPTION
Just a simple pull request so that the unit tests will work on Windows. Use the os.TempDir() function instead of hard-coding "/tmp".
